### PR TITLE
Add readsb-full

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -99,3 +99,15 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/fredclausen/docker-baseimage:rtlsdr
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Build & Push Dockerfile.readsb-full (only push if this action was NOT triggered by a PR)
+      - name: Build & Push ghcr.io/fredclausen/docker-baseimage:readsb-full
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.readsb-full
+          no-cache: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/fredclausen/docker-baseimage:readsb-full
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         "${KEPT_PACKAGES[@]}" \
-        "${TEMP_PACKAGES[@]}"\
+        "${TEMP_PACKAGES[@]}" \
         && \
     # install S6 Overlay
     curl --location --output /tmp/deploy-s6-overlay.sh https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/deploy-s6-overlay.sh && \

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -142,8 +142,8 @@ RUN set -x && \
     # readsb: copy webapp files to /usr/share/readsb/html
     mkdir -p /usr/share/readsb/html && \
     cp -Rv /src/readsb-protobuf/webapp/src/* /usr/share/readsb/html/ && \
-    mkdir -p /etc/lighttpd/config-enabled/ && \
-    cp -v /src/readsb-protobuf/debian/lighttpd/* /etc/lighttpd/conf-enabled/ && \
+    mkdir -p /etc/lighttpd/conf-available/ && \
+    cp -v /src/readsb-protobuf/debian/lighttpd/* /etc/lighttpd/conf-available/ && \
     # readsb: copy collectd files
     mkdir -p /etc/collectd/collectd.conf.d && \
     cp -v /src/readsb-protobuf/debian/collectd/readsb.collectd.conf /etc/collectd/collectd.conf.d/ && \

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -156,14 +156,14 @@ RUN set -x && \
     # bladeRF: download bladeRF FPGA images
     BLADERF_RBF_PATH="/usr/share/Nuand/bladeRF" && \
     mkdir -p "$BLADERF_RBF_PATH" && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedxA4.rbf" https://www.nuand.com/fpga/hostedxA4-latest.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedxA9.rbf" https://www.nuand.com/fpga/hostedxA9-latest.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedx40.rbf" https://www.nuand.com/fpga/hostedx40-latest.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedx115.rbf" https://www.nuand.com/fpga/hostedx115-latest.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbxA4.rbf" https://www.nuand.com/fpga/adsbxA4.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbxA9.rbf" https://www.nuand.com/fpga/adsbxA9.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbx40.rbf" https://www.nuand.com/fpga/adsbx40.rbf && \
-    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbx115.rbf" https://www.nuand.com/fpga/adsbx115.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/hostedxA4.rbf" https://www.nuand.com/fpga/hostedxA4-latest.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/hostedxA9.rbf" https://www.nuand.com/fpga/hostedxA9-latest.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/hostedx40.rbf" https://www.nuand.com/fpga/hostedx40-latest.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/hostedx115.rbf" https://www.nuand.com/fpga/hostedx115-latest.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/adsbxA4.rbf" https://www.nuand.com/fpga/adsbxA4.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/adsbxA9.rbf" https://www.nuand.com/fpga/adsbxA9.rbf && \
+    curl -L -o "$BLADERF_RBF_PATH/adsbx40.rbf" https://www.nuand.com/fpga/adsbx40.rbf &&
+    curl -L -o "$BLADERF_RBF_PATH/adsbx115.rbf" https://www.nuand.com/fpga/adsbx115.rbf && \
     # Clean up
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \
     apt-get autoremove -y && \

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -100,7 +100,6 @@ RUN set -x && \
     make install && \
     ldconfig && \
     popd && \
-
     # libad9361-iio: get latest release tag without cloning repo
     BRANCH_LIBAD9361_IIO=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/analogdevicesinc/libad9361-iio.git' | grep -v '\^' | cut -d '/' -f 3 | tail -1) && \
     # libad9361-iio: clone repo

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -139,6 +139,20 @@ RUN set -x && \
     readsb --version && \
     viewadsb --version && \
     readsbrrd --version && \
+    # readsb: copy webapp files to /usr/share/readsb/html
+    mkdir -p /usr/share/readsb/html && \
+    cp -Rv /src/readsb-protobuf/webapp/src/* /usr/share/readsb/html/ && \
+    mkdir -p /etc/lighttpd/config-enabled/ && \
+    cp -v /src/readsb-protobuf/debian/lighttpd/* /etc/lighttpd/conf-enabled/ && \
+    # readsb: copy collectd files
+    mkdir -p /etc/collectd/collectd.conf.d && \
+    cp -v /src/readsb-protobuf/debian/collectd/readsb.collectd.conf /etc/collectd/collectd.conf.d/ && \
+    mkdir -p /usr/share/readsb/graphs && \
+    cp -v /src/readsb-protobuf/debian/graphs/*.sh /usr/share/readsb/graphs/ && \
+    chmod a+x /usr/share/readsb/graphs/*.sh && \
+    # readsb: local copy of installed readsb version's protobuf proto file
+    mkdir -p /opt/readsb-protobuf && \
+    cp -v /src/readsb-protobuf/readsb.proto /opt/readsb-protobuf/readsb.proto && \
     # bladeRF: download bladeRF FPGA images
     BLADERF_RBF_PATH="/usr/share/Nuand/bladeRF" && \
     mkdir -p "$BLADERF_RBF_PATH" && \

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -1,0 +1,159 @@
+FROM ghcr.io/fredclausen/docker-baseimage:rtlsdr
+
+# hadolint ignore=DL3008,SC2086,DL4006,SC2039
+RUN set -x && \
+    TEMP_PACKAGES=() && \
+    KEPT_PACKAGES=() && \
+    # packages needed to install
+    TEMP_PACKAGES+=(git) && \
+    # packages needed to build 
+    TEMP_PACKAGES+=(build-essential) && \
+    TEMP_PACKAGES+=(cmake) && \
+    TEMP_PACKAGES+=(pkg-config) && \
+    # prerequisites for bladeRF
+    TEMP_PACKAGES+=(libusb-1.0-0-dev) && \
+    KEPT_PACKAGES+=(libncurses5) && \
+    TEMP_PACKAGES+=(libncurses5-dev) && \ 
+    KEPT_PACKAGES+=(libtecla1) && \
+    TEMP_PACKAGES+=(libtecla-dev) && \
+    # prerequisites for libiio
+    TEMP_PACKAGES+=(libusb-1.0-0-dev) && \
+    KEPT_PACKAGES+=(libserialport0) && \
+    TEMP_PACKAGES+=(libserialport-dev) && \
+    KEPT_PACKAGES+=(libxml2) && \
+    TEMP_PACKAGES+=(libxml2-dev) && \
+    TEMP_PACKAGES+=(bison) && \
+    TEMP_PACKAGES+=(flex) && \
+    KEPT_PACKAGES+=(libcdk5nc6) && \
+    TEMP_PACKAGES+=(libcdk5-dev) && \
+    KEPT_PACKAGES+=(libaio1) && \
+    TEMP_PACKAGES+=(libaio-dev) && \
+    # prerequisites for readsb-protobuf \
+    KEPT_PACKAGES+=(protobuf-c-compiler) && \
+    KEPT_PACKAGES+=(libprotobuf-c1) && \
+    TEMP_PACKAGES+=(libprotobuf-c-dev) && \
+    TEMP_PACKAGES+=(librrd-dev) && \
+    KEPT_PACKAGES+=(libncurses5) && \
+    TEMP_PACKAGES+=(libncurses5-dev) && \
+    TEMP_PACKAGES+=(binutils) && \
+    # install packages
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        "${KEPT_PACKAGES[@]}" \
+        "${TEMP_PACKAGES[@]}" \
+        && \
+    # bladeRF: get latest release tag without cloning repo
+    BRANCH_BLADERF=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Nuand/bladeRF.git' | grep -v '\^' | grep 'refs/tags/libbladeRF_' | cut -d '/' -f 3 | tail -1) && \
+    # bladeRF: clone repo
+    git clone \
+      --branch "$BRANCH_BLADERF" \
+      --depth 1 \
+      --single-branch \
+      'https://github.com/Nuand/bladeRF.git' \
+      /src/bladeRF \
+      && \
+    # bladeRF: prepare to build
+    mkdir /src/bladeRF/build && \
+    pushd /src/bladeRF/build && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DINSTALL_UDEV_RULES=ON \
+      ../ \
+      && \
+    # bladeRF: build & install
+    make -j "$(nproc)" && \
+    make install && \
+    ldconfig && \
+    popd && \
+    # bladeRF: simple test
+    bladeRF-cli --version && \
+    # libiio: get latest release tag without cloning repo
+    BRANCH_LIBIIO=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/analogdevicesinc/libiio.git' | grep -v '\^' | grep -v '.*-r.*' | cut -d '/' -f 3 | tail -1) && \
+    # libiio: clone repo
+    git clone \
+      --branch "$BRANCH_LIBIIO" \
+      --depth 1 \
+      --single-branch \
+      'https://github.com/analogdevicesinc/libiio.git' \
+      /src/libiio \
+      && \
+    # libiio: prepare to build
+    mkdir /src/libiio/build && \
+    pushd /src/libiio/build && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCSHARP_BINDINGS=OFF \
+      -DPYTHON_BINDINGS=OFF \
+      -DWITH_DOC=OFF \
+      -DWITH_MAN=OFF \
+      -DWITH_TESTS=OFF \
+      -DWITH_LOCAL_CONFIG=OFF \
+      -DWITH_HWMON=OFF \
+      -DENABLE_PACKAGING=OFF \
+      -DINSTALL_UDEV_RULE=ON \
+      -DHAVE_DNS_SD=OFF \
+      ../ \
+      && \
+    # libiio: build & install
+    make -j "$(nproc)" && \
+    make install && \
+    ldconfig && \
+    popd && \
+
+    # libad9361-iio: get latest release tag without cloning repo
+    BRANCH_LIBAD9361_IIO=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/analogdevicesinc/libad9361-iio.git' | grep -v '\^' | cut -d '/' -f 3 | tail -1) && \
+    # libad9361-iio: clone repo
+    git clone \
+      --branch "$BRANCH_LIBAD9361_IIO" \
+      --depth 1 \
+      --single-branch \
+      'https://github.com/analogdevicesinc/libad9361-iio.git' \
+      /src/libad9361-iio \
+      && \
+    # libad9361-iio: prepare to build
+    mkdir /src/libad9361-iio/build && \
+    pushd /src/libad9361-iio/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release ../ && \
+    # libad9361-iio: build & install
+    make -j "$(nproc)" && \
+    make install && \
+    ldconfig && \
+    popd && \
+    # readsb: get latest release tag without cloning repo
+    BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
+    # readsb: clone repo
+    git clone \
+      --branch "$BRANCH_READSB" \
+      --depth 1 \
+      --single-branch \
+      'https://github.com/Mictronics/readsb-protobuf.git' \
+      /src/readsb-protobuf \
+      && \
+    # readsb: build & install (note, -j seems to have issues, so not using...)
+    pushd /src/readsb-protobuf && \
+    make BLADERF=yes RTLSDR=yes PLUTOSDR=yes HAVE_BIASTEE=yes && \
+    find "/src/readsb-protobuf" -maxdepth 1 -executable -type f -exec cp -v {} /usr/local/bin/ \; && \
+    popd && \
+    ldconfig && \
+    # readsb: simple tests
+    readsb --version && \
+    viewadsb --version && \
+    readsbrrd --version && \
+    # bladeRF: download bladeRF FPGA images
+    BLADERF_RBF_PATH="/usr/share/Nuand/bladeRF" && \
+    mkdir -p "$BLADERF_RBF_PATH" && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedxA4.rbf" https://www.nuand.com/fpga/hostedxA4-latest.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedxA9.rbf" https://www.nuand.com/fpga/hostedxA9-latest.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedx40.rbf" https://www.nuand.com/fpga/hostedx40-latest.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/hostedx115.rbf" https://www.nuand.com/fpga/hostedx115-latest.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbxA4.rbf" https://www.nuand.com/fpga/adsbxA4.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbxA9.rbf" https://www.nuand.com/fpga/adsbxA9.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbx40.rbf" https://www.nuand.com/fpga/adsbx40.rbf && \
+    wget --progress=dot:mega -O "$BLADERF_RBF_PATH/adsbx115.rbf" https://www.nuand.com/fpga/adsbx115.rbf && \
+    # Clean up
+    apt-get remove -y "${TEMP_PACKAGES[@]}" && \
+    apt-get autoremove -y && \
+    rm -rf /src/* /tmp/* /var/lib/apt/lists/*
+
+ENTRYPOINT [ "/init" ]

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -162,7 +162,7 @@ RUN set -x && \
     curl -L -o "$BLADERF_RBF_PATH/hostedx115.rbf" https://www.nuand.com/fpga/hostedx115-latest.rbf && \
     curl -L -o "$BLADERF_RBF_PATH/adsbxA4.rbf" https://www.nuand.com/fpga/adsbxA4.rbf && \
     curl -L -o "$BLADERF_RBF_PATH/adsbxA9.rbf" https://www.nuand.com/fpga/adsbxA9.rbf && \
-    curl -L -o "$BLADERF_RBF_PATH/adsbx40.rbf" https://www.nuand.com/fpga/adsbx40.rbf &&
+    curl -L -o "$BLADERF_RBF_PATH/adsbx40.rbf" https://www.nuand.com/fpga/adsbx40.rbf && \
     curl -L -o "$BLADERF_RBF_PATH/adsbx115.rbf" https://www.nuand.com/fpga/adsbx115.rbf && \
     # Clean up
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \

--- a/Dockerfile.rtlsdr
+++ b/Dockerfile.rtlsdr
@@ -16,7 +16,7 @@ RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         "${KEPT_PACKAGES[@]}" \
-        "${TEMP_PACKAGES[@]}"\
+        "${TEMP_PACKAGES[@]}" \
         && \    
     # clone rtl-sdr repo
     git clone 'git://git.osmocom.org/rtl-sdr' /src/rtl-sdr && \

--- a/Dockerfile.rtlsdr
+++ b/Dockerfile.rtlsdr
@@ -39,8 +39,7 @@ RUN set -x && \
     # install
     make install && \
     ldconfig && \
-    popd && \
-    popd && \
+    popd && popd && \
     # Clean up
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \
     apt-get autoremove -y && \

--- a/Dockerfile.rtlsdr
+++ b/Dockerfile.rtlsdr
@@ -17,13 +17,17 @@ RUN set -x && \
     apt-get install -y --no-install-recommends \
         "${KEPT_PACKAGES[@]}" \
         "${TEMP_PACKAGES[@]}" \
-        && \    
-    # clone rtl-sdr repo
-    git clone 'git://git.osmocom.org/rtl-sdr' /src/rtl-sdr && \
-    pushd /src/rtl-sdr && \
-    # check out most recent tagged release
-    BRANCH_RTLSDR=$(git tag -l --sort=creatordate | tail -1) && \
-    git checkout "$BRANCH_RTLSDR" && \
+        && \
+    # rtlsdr: get latest release tag without cloning repo
+    BRANCH_RTLSDR=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'git://git.osmocom.org/rtl-sdr' | grep -v '\^' | cut -d '/' -f 3 | grep -v '^v.*' | tail -1) && \
+    # rtlsdr: clone repo
+    git clone \
+      --branch "$BRANCH_RTLSDR" \
+      --depth 1 \
+      --single-branch \
+      'git://git.osmocom.org/rtl-sdr' \
+      /src/bladeRF \
+      && \
     # prepare to build
     mkdir -p /src/rtl-sdr/build && \
     pushd /src/rtl-sdr/build && \
@@ -35,11 +39,11 @@ RUN set -x && \
       ../ \
       && \
     # build
-    make -j && \
+    make -j $(nproc) && \
     # install
     make install && \
     ldconfig && \
-    popd && popd && \
+    popd && \
     # Clean up
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \
     apt-get autoremove -y && \

--- a/Dockerfile.rtlsdr
+++ b/Dockerfile.rtlsdr
@@ -26,7 +26,7 @@ RUN set -x && \
       --depth 1 \
       --single-branch \
       'git://git.osmocom.org/rtl-sdr' \
-      /src/bladeRF \
+      /src/rtl-sdr \
       && \
     # prepare to build
     mkdir -p /src/rtl-sdr/build && \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RUN: ...
 
 ### `readsb-full`
 
-* The readsb webapp and configuration files have been included in the image (see `/usr/share/readsb/html` and `/etc/lighttpd/config-enabled`), however lighttpd has not been installed or configured. You will need to do this if you want this functionality in your image.
+* The readsb webapp and configuration files have been included in the image (see `/usr/share/readsb/html` and `/etc/lighttpd/conf-available`), however lighttpd has not been installed or configured. You will need to do this if you want this functionality in your image.
 * The collectd configuration files have been included in the image (see `/etc/collectd/collectd.conf.d` and `/usr/share/readsb/graphs`), however collectd/rrdtool have not been installed or configured. You will need to do this if you want this functionality in your image.
 * The installed version of readsb's protobuf protocol file is located at: `/opt/readsb-protobuf`, should you need this in your image.
 * bladeRF FPGA firmware images are located at: `/usr/share/Nuand/bladeRF`

--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Example:
 FROM: ghcr.io/fredclausen/docker-baseimage:rtlsdr
 RUN: ...
 ```
+
+## Tag-specific Notes
+
+### `readsb-full`
+
+* The readsb webapp and configuration files have been included in the image (see `/usr/share/readsb/html` and `/etc/lighttpd/config-enabled`), however lighttpd has not been installed or configured. You will need to do this if you want this functionality in your image.
+* The collectd configuration files have been included in the image (see `/etc/collectd/collectd.conf.d` and `/usr/share/readsb/graphs`), however collectd/rrdtool have not been installed or configured. You will need to do this if you want this functionality in your image.
+* The installed version of readsb's protobuf protocol file is located at: `/opt/readsb-protobuf`, should you need this in your image.
+* bladeRF FPGA firmware images are located at: `/usr/share/Nuand/bladeRF`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Provide a basic image, with all normal packages common to all installs of [miken
 | --- | ------- | ------------------|
 | `base` | - | [s6-overlay](https://github.com/just-containers/s6-overlay) (via [mikenye/deploy-s6-overlay](https://github.com/mikenye/deploy-s6-overlay)), [mikenye/docker-healthchecks-framework](https://github.com/mikenye/docker-healthchecks-framework), [ca-certificates](https://packages.debian.org/stable/ca-certificates), [curl](https://packages.debian.org/stable/curl), [gawk](https://packages.debian.org/stable/gawk) |
 | `rtlsdr` | `base` | [libusb](https://packages.debian.org/stable/libusb-1.0-0), [rtl-sdr](https://osmocom.org/projects/rtl-sdr/)
+| `readsb-full` | `rtlsdr` | [Mictronics/readsb-protobuf](https://github.com/Mictronics/readsb-protobuf) and all prerequisites for full functionality: ([bladeRF](https://github.com/Nuand/bladeRF), [bladeRF FPGA images](https://www.nuand.com/fpga_images/), [libiio (for PlutoSDR)](https://github.com/analogdevicesinc/libiio), [libad9361-iio (for PlutoSDR)](https://github.com/analogdevicesinc/libad9361-iio)) |
 
 ## Using
 


### PR DESCRIPTION
- Adds fully functional readsb-protobuf (as opposed to network only)
- Where we're cloning repos and checking out latest release tag, find the latest release tag first, then do a shallow clone
- Some other minor improvements to speed up builds (hopefully)