### PR TITLE
build/install latest `readsb-protobuf` rather than latest labeled version

### DIFF
--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -120,12 +120,13 @@ RUN set -x && \
     ldconfig && \
     popd && \
     # readsb: get latest release tag without cloning repo
-    # kx1t edits -- get simply the latest committed version rather than the latest tag
+    # kx1t edits -- get simply the latest committed version from the dev (=default) branch rather than the latest tag
     # this is because Mictronic doesn't update their labels very often, and important bug fixes are needlessly delayed
     # BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
+    BRANCH_READSB="dev" && \
     # readsb: clone repo
     git clone \
-    #  --branch "$BRANCH_READSB" \
+      --branch "$BRANCH_READSB" \
       --depth 1 \
       --single-branch \
       'https://github.com/Mictronics/readsb-protobuf.git' \

--- a/Dockerfile.readsb-full
+++ b/Dockerfile.readsb-full
@@ -120,10 +120,12 @@ RUN set -x && \
     ldconfig && \
     popd && \
     # readsb: get latest release tag without cloning repo
-    BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
+    # kx1t edits -- get simply the latest committed version rather than the latest tag
+    # this is because Mictronic doesn't update their labels very often, and important bug fixes are needlessly delayed
+    # BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
     # readsb: clone repo
     git clone \
-      --branch "$BRANCH_READSB" \
+    #  --branch "$BRANCH_READSB" \
       --depth 1 \
       --single-branch \
       'https://github.com/Mictronics/readsb-protobuf.git' \

--- a/Dockerfile.readsb-netonly
+++ b/Dockerfile.readsb-netonly
@@ -25,7 +25,10 @@ RUN set -x && \
         "${TEMP_PACKAGES[@]}" \
         && \
     # readsb: get latest release tag without cloning repo
-    BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
+    # kx1t edits -- get simply the latest committed version from the dev (=default) branch rather than the latest tag
+    # this is because Mictronic doesn't update their labels very often, and important bug fixes are needlessly delayed
+    # BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
+    BRACH_READSB="dev" && \
     # readsb: clone repo
     git clone \
       --branch "$BRANCH_READSB" \

--- a/Dockerfile.readsb-netonly
+++ b/Dockerfile.readsb-netonly
@@ -28,7 +28,7 @@ RUN set -x && \
     # kx1t edits -- get simply the latest committed version from the dev (=default) branch rather than the latest tag
     # this is because Mictronic doesn't update their labels very often, and important bug fixes are needlessly delayed
     # BRANCH_READSB=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/Mictronics/readsb-protobuf.git' | grep -v "\-dev" | cut -d '/' -f 3 | tail -1) && \
-    BRACH_READSB="dev" && \
+    BRANCH_READSB="dev" && \
     # readsb: clone repo
     git clone \
       --branch "$BRANCH_READSB" \


### PR DESCRIPTION
It was tested and builds fine on my local amd64 machine. I didn't test it on other architectures, but there's no reason to believe that it shouldn't be fine.