### PR TITLE
Linter changes

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -27,21 +27,6 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  yamllint:
-    name: Run yamllint against YAML files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          config_data: |
-            extends: default
-            rules:
-              line-length:
-                max: 120
-                level: warning
-
   hadolint:
     name: Run hadolint against docker files
     runs-on: ubuntu-latest
@@ -51,16 +36,6 @@ jobs:
         run: docker pull hadolint/hadolint:latest
       - name: Run hadolint against Dockerfiles
         run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
-  markdownlint:
-    name: Run markdownlint against markdown files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Pull markdownlint/markdownlint:latest Image
-        run: docker pull markdownlint/markdownlint:latest
-      - name: Run markdownlint against *.md files
-        run: docker run --rm -i -v "$(pwd)":/workdir --workdir /workdir markdownlint/markdownlint:latest --rules ~MD013,~MD033,~MD026,~MD002,~MD022 $(find . -type f -iname '*.md' | grep -v '/.git/')
 
   deploy_ghcr_base:
     name: Deploy base image to ghcr.io

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,16 +27,6 @@ jobs:
               line-length:
                 max: 120
                 level: warning
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
 
   markdownlint:
     name: Run markdownlint against markdown files


### PR DESCRIPTION
* Per #17 remove YAML/Markdown lint from the deploy action as the success of those actions shouldn't preclude deploying images if they fail.
* Per #17 remove Hadolint from linter action as the deploy action will only run if hadolint passes.