### PR TITLE
Add wreadsb-netonly image

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -454,3 +454,55 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/fredclausen/docker-baseimage:dump978-full
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy_wreadsb-netonly:
+    name: Deploy wreadsb-netonly to ghcr.io
+    needs: [deploy_ghcr_base]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      # Check out our code
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      # Log into ghcr (so we can push images)
+      - name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Get metadata from repo
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Set up QEMU for multi-arch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Set up buildx for multi platform builds
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build & Push Dockerfile (only push if this action was NOT triggered by a PR)
+      - name: Build & Push ghcr.io/fredclausen/docker-baseimage:wreadsb-netonly
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.wreadsb-netonly
+          no-cache: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/fredclausen/docker-baseimage:wreadsb-netonly
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -573,3 +573,69 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/fredclausen/docker-baseimage:dump978-full
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy_wreadsb-netonly:
+    name: Test deploy wreadsb-netonly to ghcr.io
+    needs: [deploy_ghcr_base]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      # Check out our code
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      # List of files to check to trigger a rebuild on this job
+      - name: Get specific changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v13.2
+        with:
+          files: |
+            Dockerfile$
+            Dockerfile.wreadsb-netonly
+
+      # Log into ghcr (so we can push images)
+      - name: Login to ghcr.io
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Get metadata from repo
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Set up QEMU for multi-arch builds
+      - name: Set up QEMU
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: docker/setup-qemu-action@v1
+
+      # Set up buildx for multi platform builds
+      - name: Set up Docker Buildx
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build & Push Dockerfile (only push if this action was NOT triggered by a PR)
+      - name: Build & Push ghcr.io/fredclausen/docker-baseimage:wreadsb-netonly
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.wreadsb-netonly
+          no-cache: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/fredclausen/docker-baseimage:wreadsb-netonly
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.wreadsb-netonly
+++ b/Dockerfile.wreadsb-netonly
@@ -1,0 +1,43 @@
+FROM ghcr.io/fredclausen/docker-baseimage:base
+
+# hadolint ignore=DL3008,SC2086,DL4006,SC2039
+RUN set -x && \
+    TEMP_PACKAGES=() && \
+    KEPT_PACKAGES=() && \
+    # packages needed to install
+    TEMP_PACKAGES+=(git) && \
+    # packages needed to build 
+    TEMP_PACKAGES+=(build-essential) && \
+    TEMP_PACKAGES+=(pkg-config) && \
+    # prerequisites for readsb \
+    KEPT_PACKAGES+=(libncurses5) && \
+    TEMP_PACKAGES+=(libncurses5-dev) && \
+    KEPT_PACKAGES+=(zlib1g) && \
+    TEMP_PACKAGES+=(zlib1g-dev) && \
+    # install packages
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        "${KEPT_PACKAGES[@]}" \
+        "${TEMP_PACKAGES[@]}" \
+        && \
+    # readsb: clone repo
+    git clone \
+      --branch "dev" \
+      --depth 1 \
+      --single-branch \
+      'https://github.com/wiedehopf/readsb.git' \
+      '/src/readsb' \
+      && \
+    # readsb: build & install
+    pushd /src/readsb && \
+    make -j $(nproc) && \
+    find "/src/readsb" -maxdepth 1 -executable -type f -exec cp -v {} /usr/local/bin/ \; && \
+    popd && \
+    ldconfig && \
+    # readsb: simple tests
+    readsb --version && \
+    viewadsb --version && \
+    # Clean up
+    apt-get remove -y "${TEMP_PACKAGES[@]}" && \
+    apt-get autoremove -y && \
+    rm -rf /src/* /tmp/* /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Provide a basic image, with all normal packages common to all installs of [miken
 | `python` | `base` | [python3](https://packages.debian.org/stable/python3), [python3-pip](https://packages.debian.org/stable/python3-pip), [python3-setuptools](https://packages.debian.org/stable/python3-setuptools), [python3-wheel](https://packages.debian.org/stable/python3-wheel) |
 | `readsb-full` | `rtlsdr` | Contains the latest `dev` branch of [Mictronics/readsb-protobuf](https://github.com/Mictronics/readsb-protobuf) and all prerequisites for full functionality: ([bladeRF](https://github.com/Nuand/bladeRF), [bladeRF FPGA images](https://www.nuand.com/fpga_images/), [libiio (for PlutoSDR)](https://github.com/analogdevicesinc/libiio), [libad9361-iio (for PlutoSDR)](https://github.com/analogdevicesinc/libad9361-iio)) |
 | `readsb-netonly` | `base` | Contains the latest `dev` branch of [Mictronics/readsb-protobuf](https://github.com/Mictronics/readsb-protobuf) intended to operate in network only mode. |
+| `wreadsb-netonly` | `base` | Contains the latest `dev` branch of [wiedehopf's fork of readsb](https://github.com/wiedehopf/readsb) intended to operate in network only mode. |
 | `rtlsdr` | `base` | Contains the latest tagged release of [rtl-sdr](https://osmocom.org/projects/rtl-sdr/), and prerequisites (eg: [libusb](https://packages.debian.org/stable/libusb-1.0-0)) |
 | `soapyrtlsdr` | `rtlsdr` | Contains the latest tagged release of [SoapySDR](https://github.com/pothosware/SoapySDR) and [SoapyRTLSDR](https://github.com/pothosware/SoapyRTLSDR), and prerequisites ([python3](https://packages.debian.org/stable/python3), [python3-pip](https://packages.debian.org/stable/python3-pip), [python3-setuptools](https://packages.debian.org/stable/python3-setuptools), [python3-wheel](https://packages.debian.org/stable/python3-wheel)) |
 | `dump978-full` | `soapyrtlsdr` | Contains the latest tagged release of [flightaware/dump978](https://github.com/flightaware/dump978), and prerequisites (various boost libraries) |
@@ -48,13 +49,14 @@ RUN ...
 
 ## Projects and Tag Tree
 
-| Tag              | Sub-tags Using                 | Up-Stream Projects Using |
-| ---------------- | ------------------------------ | ------------------------ |
-| `base`           | `ALL`                          | - |
-| `acars-decoder`  | -                              | [fredclausen/docker-acarsdec](https://github.com/fredclausen/docker-acarsdec), [fredclausen/docker-dumpvdl2](https://github.com/fredclausen/docker-dumpvdl2) |
-| `python`         | -                              | [fredclausen/docker-acarshub](https://github.com/fredclausen/docker-acarshub), [kx1t/docker-planefence](http://github.com/kx1t/docker-planefence), [kx1t/docker-radarvirtuel](http://github.com/kx1t/docker-radarvirtuel), [kx1t/docker-reversewebproxy](http://github.com/kx1t/docker-reversewebproxy) |
-| `rtlsdr`         | `acars-decoder`, `readsb-full`, `soapyrtlsdr` | [mikenye/piaware](https://github.com/mikenye/docker-piaware) |
-| `readsb-full`    | -                              | [mikenye/readsb-protobuf](https://github.com/mikenye/docker-readsb-protobuf) |
-| `readsb-netonly` | -                              | - |
-| `soapyrtlsdr`    | `dump978-full`                 | - |
-| `dump978-full`   | -                              | - |
+| Tag               | Sub-tags Using                 | Up-Stream Projects Using |
+| ----------------- | ------------------------------ | ------------------------ |
+| `base`            | `ALL`                          | - |
+| `acars-decoder`   | -                              | [fredclausen/docker-acarsdec](https://github.com/fredclausen/docker-acarsdec), [fredclausen/docker-dumpvdl2](https://github.com/fredclausen/docker-dumpvdl2) |
+| `python`          | -                              | [fredclausen/docker-acarshub](https://github.com/fredclausen/docker-acarshub), [kx1t/docker-planefence](http://github.com/kx1t/docker-planefence), [kx1t/docker-radarvirtuel](http://github.com/kx1t/docker-radarvirtuel), [kx1t/docker-reversewebproxy](http://github.com/kx1t/docker-reversewebproxy) |
+| `rtlsdr`          | `acars-decoder`, `readsb-full`, `soapyrtlsdr` | - |
+| `readsb-full`     | -                              | [mikenye/readsb-protobuf](https://github.com/mikenye/docker-readsb-protobuf) |
+| `readsb-netonly`  | -                              | - |
+| `soapyrtlsdr`     | `dump978-full`                 | - |
+| `dump978-full`    | -                              | [mikenye/piaware](https://github.com/mikenye/docker-piaware) |
+| `wreadsb-netonly` | -                              | - |


### PR DESCRIPTION
- Adds an image with wiedehopf's fork of readsb, network only (at this stage).
- Will be used as the base container for adsbx feeder and tar1090 visualisation.