### PR TITLE
Add qemu base image

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -506,3 +506,55 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/fredclausen/docker-baseimage:wreadsb-netonly
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy_qemu:
+    name: Deploy qemu to ghcr.io
+    needs: [deploy_ghcr_base]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      # Check out our code
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      # Log into ghcr (so we can push images)
+      - name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Get metadata from repo
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Set up QEMU for multi-arch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Set up buildx for multi platform builds
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build & Push Dockerfile (only push if this action was NOT triggered by a PR)
+      - name: Build & Push ghcr.io/fredclausen/docker-baseimage:qemu
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.qemu
+          no-cache: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/fredclausen/docker-baseimage:qemu
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -639,3 +639,69 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/fredclausen/docker-baseimage:wreadsb-netonly
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy_qemu:
+    name: Test deploy qemu to ghcr.io
+    needs: [deploy_ghcr_base]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      # Check out our code
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      # List of files to check to trigger a rebuild on this job
+      - name: Get specific changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v13.2
+        with:
+          files: |
+            Dockerfile$
+            Dockerfile.qemu
+
+      # Log into ghcr (so we can push images)
+      - name: Login to ghcr.io
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Get metadata from repo
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Set up QEMU for multi-arch builds
+      - name: Set up QEMU
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: docker/setup-qemu-action@v1
+
+      # Set up buildx for multi platform builds
+      - name: Set up Docker Buildx
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build & Push Dockerfile (only push if this action was NOT triggered by a PR)
+      - name: Build & Push ghcr.io/fredclausen/docker-baseimage:qemu
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.qemu
+          no-cache: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/fredclausen/docker-baseimage:qemu
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.qemu
+++ b/Dockerfile.qemu
@@ -1,0 +1,20 @@
+FROM ghcr.io/fredclausen/docker-baseimage:base
+
+# hadolint ignore=DL3008,SC2086,DL4006,SC2039
+RUN set -x && \
+    # Install packages
+    TEMP_PACKAGES=() && \
+    KEPT_PACKAGES=() && \
+    KEPT_PACKAGES+=(qemu-user-static) && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        "${KEPT_PACKAGES[@]}" \
+        "${TEMP_PACKAGES[@]}" \
+        && \
+    # Simple checks
+    qemu-arm-static --version && \
+    qemu-aarch64-static --version && \
+    # Clean up
+    apt-get remove -y "${TEMP_PACKAGES[@]}" && \
+    apt-get autoremove -y && \
+    rm -rf /src/* /tmp/* /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Provide a basic image, with all normal packages common to all installs of [miken
 | `rtlsdr` | `base` | Contains the latest tagged release of [rtl-sdr](https://osmocom.org/projects/rtl-sdr/), and prerequisites (eg: [libusb](https://packages.debian.org/stable/libusb-1.0-0)) |
 | `soapyrtlsdr` | `rtlsdr` | Contains the latest tagged release of [SoapySDR](https://github.com/pothosware/SoapySDR) and [SoapyRTLSDR](https://github.com/pothosware/SoapyRTLSDR), and prerequisites ([python3](https://packages.debian.org/stable/python3), [python3-pip](https://packages.debian.org/stable/python3-pip), [python3-setuptools](https://packages.debian.org/stable/python3-setuptools), [python3-wheel](https://packages.debian.org/stable/python3-wheel)) |
 | `dump978-full` | `soapyrtlsdr` | Contains the latest tagged release of [flightaware/dump978](https://github.com/flightaware/dump978), and prerequisites (various boost libraries) |
+| `qemu` | `base` | Contains `qemu-user-static` binaries |
 
 ## Using
 
@@ -60,3 +61,4 @@ RUN ...
 | `soapyrtlsdr`     | `dump978-full`                 | - |
 | `dump978-full`    | -                              | [mikenye/piaware](https://github.com/mikenye/docker-piaware) |
 | `wreadsb-netonly` | -                              | [mikenye/tar1090](https://github.com/mikenye/docker-tar1090) |
+| `qemu`            | -                              | - |


### PR DESCRIPTION
Will form the basis of radarbox, flightradar24 and any other feeders that provide ARM binaries. Using qemu, we can run ARM binaries on non-ARM systems.